### PR TITLE
Fix `assert_called_with` with an array as expected argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix `assert_called_with` with an array as expected argument.
+
 * Fix COPYRIGHT HOLDER of LICENSE.txt.
 
 ### 1.1.1 / February 26, 2019

--- a/README.md
+++ b/README.md
@@ -136,6 +136,38 @@ assert_called_with(@post, :add_comment, [["Thanks for sharing this."], ["Thanks!
 end
 ```
 
+```ruby
+assert_called_with(@post, :add_comment, [["Thanks for sharing this."]]) do
+  @post.add_comment(["Thanks for sharing this."])
+end
+```
+
+```ruby
+assert_called_with(@post, :add_comment, [["Thanks for sharing this.", "Thanks!"]]) do
+  @post.add_comment(["Thanks for sharing this.", "Thanks!"])
+end
+```
+
+```ruby
+assert_called_with(@post, :add_comment, [["Thanks for sharing this."], {body: "Thanks!"}]) do
+  @post.add_comment(["Thanks for sharing this."], {body: "Thanks!"})
+end
+```
+
+```ruby
+assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]], [{body: "Thanks!"}]]) do
+  @post.add_comment(["Thanks for sharing this."])
+  @post.add_comment({body: "Thanks!"})
+end
+```
+
+```ruby
+assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]], [["Thanks!"]]]) do
+  @post.add_comment(["Thanks for sharing this."])
+  @post.add_comment(["Thanks!"])
+end
+```
+
 ### assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)
 
 Asserts that the method will be called on an instance of the `klass` in the block

--- a/lib/minitest/mock_expectations/assertions.rb
+++ b/lib/minitest/mock_expectations/assertions.rb
@@ -98,10 +98,33 @@ module Minitest
     #     @post.add_comment("Thanks for sharing this.")
     #     @post.add_comment("Thanks!")
     #   end
+    #
+    #   assert_called_with(@post, :add_comment, [["Thanks for sharing this."]]) do
+    #     @post.add_comment(["Thanks for sharing this."])
+    #   end
+    #
+    #   assert_called_with(@post, :add_comment, [["Thanks for sharing this.", "Thanks!"]]) do
+    #     @post.add_comment(["Thanks for sharing this.", "Thanks!"])
+    #   end
+    #
+    #   assert_called_with(@post, :add_comment, [["Thanks for sharing this."], {body: "Thanks!"}]) do
+    #     @post.add_comment(["Thanks for sharing this."], {body: "Thanks!"})
+    #   end
+    #
+    #   assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]], [{body: "Thanks!"}]]) do
+    #     @post.add_comment(["Thanks for sharing this."])
+    #     @post.add_comment({body: "Thanks!"})
+    #   end
+    #
+    #   assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]], [["Thanks!"]]]) do
+    #     @post.add_comment(["Thanks for sharing this."])
+    #     @post.add_comment(["Thanks!"])
+    #   end
+    #
     def assert_called_with(object, method_name, arguments, returns: nil)
       mock = Minitest::Mock.new
 
-      if arguments.all? { |argument| argument.is_a?(Array) }
+      if arguments.size > 1 && arguments.all? { |argument| argument.is_a?(Array) }
         arguments.each { |argument| mock.expect(:call, returns, argument) }
       else
         mock.expect(:call, returns, arguments)

--- a/test/minitest/mock_expectations/assertions_test.rb
+++ b/test/minitest/mock_expectations/assertions_test.rb
@@ -146,6 +146,36 @@ class Minitest::MockExpectations::AssertionsTest < Minitest::Test
     end
   end
 
+  def test_assert_called_with_an_array_as_expected_argument
+    assert_called_with(@post, :add_comment, [["Thanks for sharing this."]]) do
+      @post.add_comment(["Thanks for sharing this."])
+    end
+
+    assert_called_with(@post, :add_comment, [["Thanks for sharing this.", "Thanks!"]]) do
+      @post.add_comment(["Thanks for sharing this.", "Thanks!"])
+    end
+  end
+
+  def test_assert_called_with_multiple_expected_arguments_as_arrays
+    assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]], [["Thanks!"]]]) do
+      @post.add_comment(["Thanks for sharing this."])
+      @post.add_comment(["Thanks!"])
+    end
+  end
+
+  def test_assert_called_with_expected_arguments_as_array_and_one_non_array_object
+    assert_called_with(@post, :add_comment, [["Thanks for sharing this."], {body: "Thanks!"}]) do
+      @post.add_comment(["Thanks for sharing this."], {body: "Thanks!"})
+    end
+  end
+
+  def test_assert_called_with_multiple_expected_arguments_as_array_and_one_non_array_object
+    assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]], [{body: "Thanks!"}]]) do
+      @post.add_comment(["Thanks for sharing this."])
+      @post.add_comment({body: "Thanks!"})
+    end
+  end
+
   def test_assert_called_on_instance_of_with_defaults_to_expect_once
     assert_called_on_instance_of(Post, :title) do
       @post.title


### PR DESCRIPTION
Fixes #4

There is a suggestion to change API of `assert_called_with` to
allow providing a different return value for each set of arguments.
It is a superb suggestion, but I currently hesitate to change the API in
that way. Let's not rush with changing the API.

```ruby
expectations = [
  {
    expected_args: ["Thanks for sharing this."],
    return_value: mocked_comment_1
  },
  {
    expected_args:  ["Thanks!"],
    return_value: mocked_comment_2
  }
]

assert_called_with(@post, :add_comment, expectations: expectations) do
  @post.add_comment("Thanks for sharing this.")
  @post.add_comment("Thanks!")
end
```

Thank you @thatguysimon for finding that bug, reporting the issue and
suggesting to imporve the API of `assert_called_with`, I appreciate that.