### PR TITLE
Revert "Fix `assert_called_with` with an array as expected argument."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Revert "Fix `assert_called_with` with an array as expected argument.".
+
 ### 1.1.2 / April 24, 2020
 
 * Fix `assert_called_with` with an array as expected argument.

--- a/README.md
+++ b/README.md
@@ -137,14 +137,20 @@ end
 ```
 
 ```ruby
-assert_called_with(@post, :add_comment, [["Thanks for sharing this."]]) do
+assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]]]) do
   @post.add_comment(["Thanks for sharing this."])
 end
 ```
 
 ```ruby
-assert_called_with(@post, :add_comment, [["Thanks for sharing this.", "Thanks!"]]) do
+assert_called_with(@post, :add_comment, [[["Thanks for sharing this.", "Thanks!"]]]) do
   @post.add_comment(["Thanks for sharing this.", "Thanks!"])
+end
+```
+
+```ruby
+assert_called_with(@post, :add_comment, [[["Thanks for sharing this."], ["Thanks!"]]]) do
+  @post.add_comment(["Thanks for sharing this."], ["Thanks!"])
 end
 ```
 

--- a/lib/minitest/mock_expectations/assertions.rb
+++ b/lib/minitest/mock_expectations/assertions.rb
@@ -99,12 +99,16 @@ module Minitest
     #     @post.add_comment("Thanks!")
     #   end
     #
-    #   assert_called_with(@post, :add_comment, [["Thanks for sharing this."]]) do
+    #   assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]]]) do
     #     @post.add_comment(["Thanks for sharing this."])
     #   end
     #
-    #   assert_called_with(@post, :add_comment, [["Thanks for sharing this.", "Thanks!"]]) do
+    #   assert_called_with(@post, :add_comment, [[["Thanks for sharing this.", "Thanks!"]]]) do
     #     @post.add_comment(["Thanks for sharing this.", "Thanks!"])
+    #   end
+    #
+    #   assert_called_with(@post, :add_comment, [[["Thanks for sharing this."], ["Thanks!"]]]) do
+    #     @post.add_comment(["Thanks for sharing this."], ["Thanks!"])
     #   end
     #
     #   assert_called_with(@post, :add_comment, [["Thanks for sharing this."], {body: "Thanks!"}]) do
@@ -124,7 +128,7 @@ module Minitest
     def assert_called_with(object, method_name, arguments, returns: nil)
       mock = Minitest::Mock.new
 
-      if arguments.size > 1 && arguments.all? { |argument| argument.is_a?(Array) }
+      if arguments.all? { |argument| argument.is_a?(Array) }
         arguments.each { |argument| mock.expect(:call, returns, argument) }
       else
         mock.expect(:call, returns, arguments)

--- a/test/minitest/mock_expectations/assertions_test.rb
+++ b/test/minitest/mock_expectations/assertions_test.rb
@@ -147,12 +147,18 @@ class Minitest::MockExpectations::AssertionsTest < Minitest::Test
   end
 
   def test_assert_called_with_an_array_as_expected_argument
-    assert_called_with(@post, :add_comment, [["Thanks for sharing this."]]) do
+    assert_called_with(@post, :add_comment, [[["Thanks for sharing this."]]]) do
       @post.add_comment(["Thanks for sharing this."])
     end
 
-    assert_called_with(@post, :add_comment, [["Thanks for sharing this.", "Thanks!"]]) do
+    assert_called_with(@post, :add_comment, [[["Thanks for sharing this.", "Thanks!"]]]) do
       @post.add_comment(["Thanks for sharing this.", "Thanks!"])
+    end
+  end
+
+  def test_assert_called_with_expected_arguments_as_arrays
+    assert_called_with(@post, :add_comment, [[["Thanks for sharing this."], ["Thanks!"]]]) do
+      @post.add_comment(["Thanks for sharing this."], ["Thanks!"])
     end
   end
 


### PR DESCRIPTION
Reverts https://github.com/bogdanvlviv/minitest-mock_expectations/pull/5
Related to https://github.com/bogdanvlviv/minitest-mock_expectations/issues/4

To fix issue with
```ruby
assert_called_with(Tempfile, :new, [['hello', '.jpg']]) do
  file = Tempfile.new(['hello', '.jpg'])
end
```

changed it to

```ruby
assert_called_with(Tempfile, :new, [[['hello', '.jpg']]]) do
  file = Tempfile.new(['hello', '.jpg'])
end
```

Looks ugly but, otherwise it isn't possible to make an assertion like:

```ruby
assert_called_with(@post, :add_comment, [[["Thanks for sharing this."], ["Thanks!"]]]) do
  @post.add_comment(["Thanks for sharing this."], ["Thanks!"])
end
```

This change makes it possible